### PR TITLE
Exclude columns of primary key from "belongsTo"

### DIFF
--- a/src/Shell/Task/ModelTask.php
+++ b/src/Shell/Task/ModelTask.php
@@ -323,7 +323,7 @@ class ModelTask extends BakeTask
     {
         $schema = $model->getSchema();
         foreach ($schema->columns() as $fieldName) {
-            if (!preg_match('/^.+_id$/', $fieldName)) {
+            if (!preg_match('/^.+_id$/', $fieldName) || in_array($fieldName, $schema->primaryKey())) {
                 continue;
             }
 


### PR DESCRIPTION
When a database table contains a column that ends with "_id" by convention it is treated as a foreign key. I stumbled upon a schema where regular primary keys were named in this manner (i.e. "usr_id" was primary key of "users" table, etc.), which of course misled bake. This change introduces a check to skip such fields from being treated as associations when they belong to table's primary key.